### PR TITLE
Prevent double encoding of url's with the add to basket buttons

### DIFF
--- a/js/modules/global/basketitem.js
+++ b/js/modules/global/basketitem.js
@@ -136,10 +136,10 @@
 
 	$.fn.basketItem.defaults = {
 		method : 'POST',
-		addUrl : _u('/basket/rest/add.json'),
-		removeUrl : _u('/basket/rest/delete.json'),
-		incrementUrl : _u('/basket/rest/incr.json'),
-		decrementUrl : _u('/basket/rest/decr.json'),
+		addUrl : '/basket/rest/add.json',
+		removeUrl : '/basket/rest/delete.json',
+		incrementUrl : '/basket/rest/incr.json',
+		decrementUrl : '/basket/rest/decr.json',
 		productId : ''
 	};
 


### PR DESCRIPTION
Er gerd! Whealer double based these URL's. Let's get into the habbit of basing them only at the point of using them.